### PR TITLE
Adding Log Outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,18 +99,27 @@ jobs:
           docker manifest rm ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:latest || true
           docker manifest rm ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:${{ env.SQUID_VERSION }} || true
 
+      - name: List Docker images for verification
+        run: |
+          echo "Listing all Docker images:"
+          docker images
+
       - name: Create and push multi-arch manifest for "latest" tag
         run: |
+          echo "Creating multi-arch manifest for 'latest' tag..."
           docker manifest create ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:latest \
-            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:linux/amd64 \
-            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:linux/arm/v7 \
-            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:linux/s390x
+            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:latest \
+            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:linux-arm-v7 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:linux-s390x
+          echo "Pushing 'latest' manifest..."
           docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:latest
 
       - name: Create and push multi-arch manifest for versioned tag
         run: |
+          echo "Creating multi-arch manifest for versioned tag (${ env.SQUID_VERSION })..."
           docker manifest create ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:${{ env.SQUID_VERSION }} \
             ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:${{ env.SQUID_VERSION }} \
-            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:linux/arm/v7 \
-            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:linux/s390x
+            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:linux-arm-v7 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:linux-s390x
+          echo "Pushing versioned manifest..."
           docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/squid-proxy:${{ env.SQUID_VERSION }}


### PR DESCRIPTION
Add a docker images command before the docker manifest create step to list all available images and verify their names.